### PR TITLE
Fix for missing imports in modals.less

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,14 +1264,14 @@
     <div class="section">
       <h2 id="download">Download and Link</h2>
       <h4>Download</h4>
-      <p>Download the latest version (1.3.0) using either of the links below. Or download an older release via Github.</p>
+      <p>Download the latest version (1.3.1) using either of the links below. Or download an older release via Github.</p>
       <div class="row flex-spaces text-center">
-        <a class="paper-btn margin" href="https://github.com/papercss/papercss/releases/download/v1.3.0/paper.css">CSS File</a>
-        <a class="paper-btn margin" href="https://github.com/papercss/papercss/releases/download/v1.3.0/paper.min.css">Minified CSS File</a>
+        <a class="paper-btn margin" href="https://github.com/papercss/papercss/releases/download/v1.3.1/paper.css">CSS File</a>
+        <a class="paper-btn margin" href="https://github.com/papercss/papercss/releases/download/v1.3.1/paper.min.css">Minified CSS File</a>
         <a class="paper-btn margin" href="https://github.com/papercss/papercss/releases">Github Releases</a>
       </div>
       <h4>NPM</h4>
-      <p>PaperCSS is now available on NPM as of version 1.3.0. Install with <code>npm install papercss --save</code> and find the CSS in:</p>
+      <p>PaperCSS is now available on NPM as of version 1.3.1. Install with <code>npm install papercss --save</code> and find the CSS in:</p>
       <ul>
         <li>node_modules/papercss/dist/paper.css</li>
         <li>node_modules/papercss/dist/paper.min.css</li>
@@ -1279,8 +1279,8 @@
       <h4>CDN</h4>
       <p>Don't want to download it? That's cool. You can just link to PaperCSS via <a href="https://unpkg.com/#/">unpkg's CDN</a>. You can use either:</p>
       <ul>
-        <li><a href="https://unpkg.com/papercss@1.3.0/dist/paper.css">https://unpkg.com/papercss@1.3.0/dist/paper.css</a></li>
-        <li><a href="https://unpkg.com/papercss@1.3.0/dist/paper.min.css">https://unpkg.com/papercss@1.3.0/dist/paper.min.css</a></li>
+        <li><a href="https://unpkg.com/papercss@1.3.1/dist/paper.css">https://unpkg.com/papercss@1.3.1/dist/paper.css</a></li>
+        <li><a href="https://unpkg.com/papercss@1.3.1/dist/paper.min.css">https://unpkg.com/papercss@1.3.1/dist/paper.min.css</a></li>
       </ul>
       <p>Here's a quck snippet to get started with PaperCSS:</p>
       <div class="docs">
@@ -1290,7 +1290,7 @@
   &lt;meta charset=&quot;UTF-8&quot;&gt;
   &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1.0&quot;&gt;
   &lt;meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;ie=edge&quot;&gt;
-  &lt;link rel=&quot;stylesheet&quot; href=&quot;https://unpkg.com/papercss@1.3.0/dist/paper.min.css&quot;&gt;
+  &lt;link rel=&quot;stylesheet&quot; href=&quot;https://unpkg.com/papercss@1.3.1/dist/paper.min.css&quot;&gt;
   &lt;title&gt;Document&lt;/title&gt;
 &lt;/head&gt;
 &lt;body&gt;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papercss",
-  "version": "1.3.0",
-  "description": "Another CSS framework",
+  "version": "1.3.1",
+  "description": "The less formal CSS framework.",
   "main": "index.js",
   "scripts": {
     "start": "node node_modules/gulp/bin/gulp.js",

--- a/src/modals.less
+++ b/src/modals.less
@@ -1,3 +1,7 @@
+@import './colors.less';
+@import './container.less';
+@import './utilities.less';
+
 .translate(@x; @y) {
   -webkit-transform: translate(@x, @y);
   -ms-transform: translate(@x, @y);
@@ -15,24 +19,24 @@
 }
 
 .modal{
-  
+
   &:before{
-    content: ""; 
+    content: "";
     display: none;
     background: rgba(0,0,0,.6);
     position: fixed;
-    top: 0; left: 0; right: 0; bottom: 0; 
+    top: 0; left: 0; right: 0; bottom: 0;
     z-index: 10;
   }
 
   &:target{
-  
+
     &:before{
       display: flex;
-    }  
+    }
     .modal-body{
-      .translate(0, 0); 
-      top: 20%;  
+      .translate(0, 0);
+      top: 20%;
     }
   }
 
@@ -65,7 +69,7 @@
     &:hover{
       color: @muted;
     }
-    
+
   }
 
   .modal-title, h4 {

--- a/src/modals.less
+++ b/src/modals.less
@@ -7,10 +7,6 @@
   -ms-transform: translate(@x, @y);
   transform: translate(@x, @y);
 }
-.transition(@transition) {
-  -webkit-transition: @transition;
-  transition: @transition;
-}
 .transition-transform(@transition) {
   -webkit-transition: -webkit-transform @transition;
   -moz-transition: -moz-transform @transition;


### PR DESCRIPTION
## Brief description

`modals.less` have missing imports, which breaks `gulp build`. This is been fixed and need to prepare papercss for 1.3.1, as said in #116. This needs to be merged ASAP.

Waiting for @rhyneav to prepare for 1.3.1. Once you have added your commits, this can be merged without any errors/problems.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.