### PR TITLE
hotfix-animationbug

### DIFF
--- a/src/components/_cards.scss
+++ b/src/components/_cards.scss
@@ -5,6 +5,8 @@
   flex-direction: column;
   word-wrap: break-word;
   border: 2px solid $muted-light;
+  backface-visibility: hidden;
+  will-change: transform;
 
   &:hover {
     @include shadow(hover);

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -170,6 +170,13 @@ $shadow-hover: 2px 8px 8px -5px $shadow-color-hover !default;
   }
 }
 
+/*
+  Add transform: translate() with browser prefixes.
+  Same syntax for translate() and translate3d()
+  To get 3D add a $z value and set 'true'
+  @param string | boolean
+  @default 0 | false
+*/
 @mixin translate($x, $y, $z: 0, $transform3d: false) {
   @if $transform3d {
     -webkit-transform: translate3d($x, $y, $z);

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -170,10 +170,16 @@ $shadow-hover: 2px 8px 8px -5px $shadow-color-hover !default;
   }
 }
 
-@mixin translate($x, $y) {
-  -webkit-transform: translate($x, $y);
-  -ms-transform: translate($x, $y);
-  transform: translate($x, $y);
+@mixin translate($x, $y, $z: 0, $transform3d: false) {
+  @if $transform3d {
+    -webkit-transform: translate3d($x, $y, $z);
+    -ms-transform: translate3d($x, $y, $z);
+    transform: translate3d($x, $y, $z);
+  } @else {
+    -webkit-transform: translate($x, $y);
+    -ms-transform: translate($x, $y);
+    transform: translate($x, $y);
+  }
 }
 
 /*
@@ -196,7 +202,7 @@ $shadow-hover: 2px 8px 8px -5px $shadow-color-hover !default;
 @mixin shadow($type: regular) {
   @if $type == hover {
     box-shadow: $shadow-hover;
-    @include translate(0, 2px);
+    @include translate(0, 2px, 0, true);
   } @else if $type == small {
     @include transition($animation: ease);
     box-shadow: $shadow-small;


### PR DESCRIPTION
## Brief description
This should fix the bug described in https://github.com/papercss/papercss/issues/111

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Further details
I added the [`will-change: transform`](https://dev.opera.com/articles/css-will-change-property/) and [`backface-visibility: hidden`](https://css-tricks.com/almanac/properties/b/backface-visibility/)  directives to the `.cards` component.

tl;dr

> The will-change property allows you to inform the browser ahead of time of what kinds of changes you are likely to make to an element, so that it can set up the appropriate optimizations before they’re needed, therefore avoiding a non-trivial start-up cost which can have a negative effect on the responsiveness of a page. **The elements can be changed and rendered faster, and the page will be able to update snappily, resulting in a smoother experience.**

`backface-visibility` shouldn't do anything, since `translate` is a 2D transform, but it *feels* smoother, so I  kept it.