### PR TITLE
Fixing typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are several options available:
 
 We provide compiled CSS (`paper.css`) as well as minified CSS (`paper.min.css`).
 
-You can choose which components you may want to use. Only the components that get imported in `src/styles.scss` will be compoiled into `dist/paper.css`.
+You can choose which components you may want to use. Only the components that get imported in `src/styles.scss` will be compiled into `dist/paper.css`.
 
 You can also play with original, source files, written in SCSS, in `src/`.
 


### PR DESCRIPTION
## Brief description
Fixed a typo in the readme.

## Developer Certificate of Origin

- [X ] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.
