### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,9 @@ before_script:
     - gulp build
 
 script: "./jake.sh loose=true capture=Firefox"
+
+before_install:
+  - npm i -g npm@latest
+
+install:
+  - npm ci


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable