### PR TITLE
Update _lists.scss

### DIFF
--- a/src/content/_lists.scss
+++ b/src/content/_lists.scss
@@ -25,6 +25,10 @@ ul {
 
   li {
     text-indent: -7px;
+    
+    .badge {
+      text-indent: 0;
+    }
 
     &::before {
       left: -7px;


### PR DESCRIPTION
Fix for badges in unordered lists.

## Brief description
Padding doesn't come out right on badges added to unordered lists.
![screen shot 2018-09-13 at 4 45 16 pm](https://user-images.githubusercontent.com/458367/45514825-7877b300-b774-11e8-9ac8-271dee75695c.png)

...

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures
Should look like so.
![screen shot 2018-09-13 at 4 45 21 pm](https://user-images.githubusercontent.com/458367/45514832-7dd4fd80-b774-11e8-8687-e72038bbb146.png)

...

## Further details

...