### PR TITLE
Keyboard control on radio buttons bug fix

### DIFF
--- a/src/components/_forms.scss
+++ b/src/components/_forms.scss
@@ -64,9 +64,9 @@ select {
     /* the basic, unchecked style */
     input {
       border: 0;
-      display: none;
       height: 1px;
       margin: -1px;
+      opacity: 0;
       overflow: hidden;
       padding: 0;
       position: absolute;


### PR DESCRIPTION
## Brief description

Fix for https://github.com/papercss/papercss/issues/162.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

...

## Further details

Simple fix required inputs having a property `opacity: 0;` instead of `display: none;`.
