### PR TITLE
Fix percentage calculation in progress bar for loop

### DIFF
--- a/src/components/_progress.scss
+++ b/src/components/_progress.scss
@@ -35,7 +35,7 @@
 
     @for $i from 0 through 100 {
       &.w-#{$i} {
-        width: $i + %;
+        width: $i * 1%;
       }
     }
   


### PR DESCRIPTION
## Brief description

It seems like progress bar percentage calculation doesn't work with sass-loader.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

None

## Further details

I've got this issue while trying to use sass files with Symfony Encore and sass-loader (based on Webpack).

```
D:\projets\ansible-vagrant\html\www.symfony.vbox>yarn encore dev
yarn run v1.9.4
$ D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\.bin\encore dev
Running webpack ...

 ERROR  Failed to compile with 1 errors                                                                                                                                                                                              22:57:03

 error  in ./assets/css/app.scss

Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/lib/loader.js):

undefined
                   ^
      Invalid CSS after "...    width: $i +": expected expression (e.g. 1px, bold), was "%;"
      in D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\papercss\src\components\_progress.scss (line 38, column 21)
    at runLoaders (D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\webpack\lib\NormalModule.js:301:20)
    at D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\loader-runner\lib\LoaderRunner.js:364:11
    at D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\loader-runner\lib\LoaderRunner.js:230:18
    at context.callback (D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\loader-runner\lib\LoaderRunner.js:111:13)
    at Object.asyncSassJobQueue.push [as callback] (D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\sass-loader\lib\loader.js:76:13)
    at Object.done [as callback] (D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\neo-async\async.js:8077:18)
    at options.error (D:\projets\ansible-vagrant\html\www.symfony.vbox\node_modules\node-sass\lib\index.js:294:32)

 @ ./assets/js/app.js 2:0-26

Entrypoint app = runtime.js app.js
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Doing a `$i * 1%` instead of `$i + %` fixes the error. `$i + '%'` works too.