### PR TITLE
Fix hover transition on .paper-btn anchors

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -9,7 +9,7 @@ button,
   border: 2px solid $primary;
   color: $primary;
   cursor: pointer;
-  display: inline;
+  display: inline-block;
   font-size: 1rem;
   outline: none;
   padding: 0.75rem;


### PR DESCRIPTION
## Brief description

.paper-btn anchor are not playing hover transition.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

![Steps to reproduce](https://i.imgur.com/Hv9CBUG.gif)

## Further details

You can reproduce on https://www.getpapercss.com/docs/components/buttons/. When hovering buttons, they go slightly down, but when hovering links, they don't.

Changing `display: inline` to `display: inline-block` fixes the issue.
