### PR TITLE
Tabs Content Alignment Bugfix

### DIFF
--- a/src/components/_tabs.scss
+++ b/src/components/_tabs.scss
@@ -2,6 +2,7 @@
   .content {
     display: none;
     padding: 0.75rem 0 0;
+    flex-basis: 100%;
   }
 
   input {


### PR DESCRIPTION
Fixes Bug where the content would be aligned right next to the tabs on larger screens.

See: https://github.com/papercss/papercss/issues/202