### PR TITLE
navbar docs hamburger menu not showing fix

### DIFF
--- a/docs/content/docs/components/navbar.md
+++ b/docs/content/docs/components/navbar.md
@@ -10,9 +10,9 @@ description: PaperCSS Navbar
   <div class="collapsible">
     <input id="collapsible0" type="checkbox" name="collapsible0">
     <label for="collapsible0">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <div class="bar1 border"></div>
+      <div class="bar2 border"></div>
+      <div class="bar3 border"></div>
     </label>
     <div class="collapsible-body">
       <ul class="inline">
@@ -31,9 +31,9 @@ description: PaperCSS Navbar
   <div class="collapsible">
     <input id="collapsible1" type="checkbox" name="collapsible1">
     <label for="collapsible1">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <div class="bar1 border"></div>
+      <div class="bar2 border"></div>
+      <div class="bar3 border"></div>
     </label>
     <div class="collapsible-body">
       <ul class="inline">
@@ -57,9 +57,9 @@ Add ```.fixed``` to ```<nav>``` to fix the nav to the top to have it scroll the 
   <div class="collapsible">
     <input id="collapsible1" type="checkbox" name="collapsible1">
     <label for="collapsible1">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <div class="bar1 border"></div>
+      <div class="bar2 border"></div>
+      <div class="bar3 border"></div>
     </label>
     <div class="collapsible-body">
       <ul class="inline">
@@ -81,9 +81,9 @@ Add ```.fixed``` to ```<nav>``` to fix the nav to the top to have it scroll the 
   <div class="collapsible">
     <input id="collapsible2" type="checkbox" name="collapsible2">
     <label for="collapsible2">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <div class="bar1 border"></div>
+      <div class="bar2 border"></div>
+      <div class="bar3 border"></div>
     </label>
     <div class="collapsible-body">
       <ul class="inline">
@@ -105,9 +105,9 @@ Add ```.fixed``` to ```<nav>``` to fix the nav to the top to have it scroll the 
   <div class="collapsible">
     <input id="collapsible2" type="checkbox" name="collapsible2">
     <label for="collapsible2">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <div class="bar1 border"></div>
+      <div class="bar2 border"></div>
+      <div class="bar3 border"></div>
     </label>
     <div class="collapsible-body">
       <ul class="inline">


### PR DESCRIPTION
## Brief description

Currently https://www.getpapercss.com/docs/components/navbar/ collapsed navbar hamburger menu is invisible.
This can be fixed by adding "border" to the bars.

## Sample pictures

Firefox:
![image](https://user-images.githubusercontent.com/45269051/101613768-d27b8780-3a14-11eb-8fab-d7c9ccc797f6.png)
Chromium:
![image](https://user-images.githubusercontent.com/45269051/101614059-25553f00-3a15-11eb-8cd7-0e4a67917986.png)
