### PR TITLE
Enable "font-display: swap " to avoid showing invisible text

### DIFF
--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -3,7 +3,7 @@
 */
 
 // The src for fonts (false to disable)
-$font-src: 'https://fonts.googleapis.com/css?family=Neucha|Patrick+Hand+SC' !default;
+$font-src: 'https://fonts.googleapis.com/css?family=Neucha|Patrick+Hand+SC&display=swap' !default;
 
 // Imports
 @if $font-src {


### PR DESCRIPTION
## Brief description
The PR adds a change in the _config.scss file to enable font-display: swap.  This instructs browsers to use the fallback font to display the text until the custom font has fully downloaded. Also helps with performance so you get that 100 score on lighthouse 😁
...

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

...

## Further details
This PR closes #260 

...
