### PR TITLE
set select background color

### DIFF
--- a/src/components/_forms.scss
+++ b/src/components/_forms.scss
@@ -28,6 +28,7 @@ textarea {
 }
 
 select {
+  @include color('background-color', 'main-background');
   height: 2.35rem;
 }
 


### PR DESCRIPTION
## Brief description

Set a background color for select elements as options was unreadable with dark mode.

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

Before: 
![image](https://user-images.githubusercontent.com/13274293/213890069-5cb3858e-90c1-463f-aef9-bbbe03a38372.png)

After: 
![image](https://user-images.githubusercontent.com/13274293/213890077-ef31fb52-9e30-464a-bc93-704365cf2f8a.png)

