### PR TITLE
Remove newline on nested <li><p></p></li>

### DIFF
--- a/src/content/_lists.scss
+++ b/src/content/_lists.scss
@@ -38,6 +38,10 @@ ul {
       left: -7px;
       position: relative;
     }
+    
+    & > p {
+      display: inline;
+    }
   }
 
   ul {


### PR DESCRIPTION
## Brief description
Addresses unwanted newlines when using `<li>` tags with nested `<p>` tags. 

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures
![image](https://user-images.githubusercontent.com/63316287/214730132-c363f10b-94ab-4854-82a9-55cc6b65b073.png)

![image](https://user-images.githubusercontent.com/63316287/214730176-4c795ffa-48c6-4937-9ce3-4110feca6fe5.png)

## Further details
Address #292 
Running `npm run css:build` made a lot of changes to the CSS outside of this fix, so this PR doesn't include the updated CSS itself just the SASS changes. I can open one up to push all the current changes on dev if needed. 

