### PR TITLE
Set visibility of popovers, avoid trigger when hovering invisible pseudoelement

### DIFF
--- a/src/components/_popovers.scss
+++ b/src/components/_popovers.scss
@@ -10,7 +10,7 @@
   &:hover {
     &::after {
       opacity: 1;
-      transition: opacity 0.2s ease-out, visibility 0s linear 0s;
+      transition: opacity 235ms ease-in-out, visibility 0s linear;
       visibility: visible;
     }
   }
@@ -33,7 +33,7 @@
     text-align: center;
     top: -6px;
     transform: translateX(-50%) translateY(-100%);
-    transition: opacity 0.2s ease-out, visibility 0s linear 0.2s;
+    transition: opacity 235ms ease-in-out, visibility 0s linear 0.2s;
     visibility: hidden;
   }
 }

--- a/src/components/_popovers.scss
+++ b/src/components/_popovers.scss
@@ -18,7 +18,6 @@
   // Creating popover::after element
   &::after {
     @include border-style();
-    @include transition(opacity);
     @include color('background-color', 'light-dark');
     @include color('border-color', 'light-dark');
     @include color('color', 'primary-inverse');

--- a/src/components/_popovers.scss
+++ b/src/components/_popovers.scss
@@ -32,7 +32,7 @@
     text-align: center;
     top: -6px;
     transform: translateX(-50%) translateY(-100%);
-    transition: opacity 235ms ease-in-out, visibility 0s linear 0.2s;
+    transition: opacity 235ms ease-in-out, visibility 0s linear 235ms;
     visibility: hidden;
   }
 }

--- a/src/components/_popovers.scss
+++ b/src/components/_popovers.scss
@@ -10,7 +10,8 @@
   &:hover {
     &::after {
       opacity: 1;
-      transition: opacity 0.2s ease-out;
+      transition: opacity 0.2s ease-out, visibility 0s linear 0s;
+      visibility: visible;
     }
   }
 
@@ -32,6 +33,8 @@
     text-align: center;
     top: -6px;
     transform: translateX(-50%) translateY(-100%);
+    transition: opacity 0.2s ease-out, visibility 0s linear 0.2s;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
## Brief description

This PR is intended to fix #297, such that popovers do not appear when hovering over the area occupied by the (still invisible) popover. This can be important if other elements are beneath that area, and also [improves accessibility](https://css-tricks.com/snippets/css/toggle-visibility-when-hiding-elements/).

Unfortunately I'm having trouble getting the local development server running to test this change. In CONTRIBUTING.md I don't see anything about installing Hugo — do I need to do anything manually there? I'm on macOS. When running `npm run dev` I get errors like "node_modules/hugo-bin/vendor EACCES", or when installing Hugo manually and running ` hugo server --source=docs --disableFastRender` I get the error:

> `Configured defaultMarkdownHandler "blackfriday" not found. Did you mean to use goldmark? Blackfriday was removed in Hugo v0.100.0."`

I tried manually switching the markdown handler, Hugo runs and the site loads, but the demo PaperCSS components are missing from the site preview.

Thanks!

## Developer Certificate of Origin

- [x] I certify that these changes according to the Developer Certificate of Origin 1.1 as described at <https://developercertificate.org/>.

## Sample pictures

N/A

## Further details

- Fixes #297 
